### PR TITLE
Add preprocessed dataset links

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ pip install -e .
 
 Please download the Mip-NeRF 360 dataset from the [official webiste](https://jonbarron.info/mipnerf360/), the NeRF-Synthetic dataset from the [NeRF's official Google Drive](https://drive.google.com/drive/folders/128yBriW1IG_3NJ5Rp7APSTZsJqdJdfc1), the preprocessed DTU dataset from [2DGS](https://surfsplatting.github.io/), the proprocessed Tanks and Temples dataset from [here](https://huggingface.co/datasets/ZehaoYu/gaussian-opacity-fields/tree/main). You need to download the ground truth point clouds from the [DTU dataset](https://roboimagedata.compute.dtu.dk/?page_id=36) and save to `dtu_eval/Offical_DTU_Dataset` to evaluate the geometry reconstruction. For the [Tanks and Temples](https://www.tanksandtemples.org/download/) dataset, you need to download the ground truth point clouds, alignments and cropfiles and save to `eval_tnt/TrainingSet`, such as `eval_tnt/TrainingSet/Caterpillar/Caterpillar.ply`.
 
+# Preprocessed Dataset
+The preprocessed surface reconstruction datasets (DTU, BlendedMVS, MobileBrick) are generated using the ground truth poses and triangulation from COLMAP. The datasets have been converted to the COLMAP format. You can download the processed datasets from [gaustudio-dataset](https://cuhko365-my.sharepoint.com/:f:/g/personal/118010378_link_cuhk_edu_cn/En7TRlmsyTtMor40XQlUswMBLy63gqItvrV5z0gRiiXjOg?e=mggVpx).
+
 
 # Training and Evaluation
 ```


### PR DESCRIPTION
Thanks for your excellent work! We have added a link to preprocessed datasets included various conventional surface reconstruction datasets (DTU, BlendedMVS, MobileBrick) as well as some novel view synthetic datasets (nerf_synthetic, nero_synthetic, NSVF_synthetic, refnerf_synthetic). The synthetic datasets encompass challenging scenarios such as low-texture regions, reflective surfaces, and complex geometries. This diverse collection will allow us to thoroughly evaluate the robustness and performance of reconstruction methods, particularly in handling difficult cases.
<img width="1133" alt="image" src="https://github.com/autonomousvision/gaussian-opacity-fields/assets/40767265/c035d663-ff75-4259-b6d6-c2a965aaae0f">

The images and ground truth poses for the DTU dataset are obtained from [NeuS](https://github.com/Totoro97/NeuS). For BlendedMVS and MobileBrick, the data is sourced from their respective original repositories: https://github.com/YoYo000/BlendedMVS and https://github.com/ActiveVisionLab/MobileBrick. After extracting the data from these sources, we can directly evaluate the mesh by following the instructions provided in the corresponding original repositories.