### PR TITLE
Fix type names in forward.cu

### DIFF
--- a/submodules/diff-gaussian-rasterization/cuda_rasterizer/forward.cu
+++ b/submodules/diff-gaussian-rasterization/cuda_rasterizer/forward.cu
@@ -980,7 +980,7 @@ integrateCUDA(
 				// pixel.
 				last_contributor = contributor;
 
-				contributed_ids[n_contrib_local] = (u_int16_t)contributor;
+				contributed_ids[n_contrib_local] = (uint16_t)contributor;
 				n_contrib_local += 1;
 
 				if (n_contrib_local >= MAX_NUM_CONTRIBUTORS * 4){
@@ -1142,7 +1142,7 @@ integrateCUDA(
 					second_done = true;
 					continue;
 				}
-				if (num_iterated != (u_int32_t)contributed_ids[num_contributed_second]){
+				if (num_iterated != (uint32_t)contributed_ids[num_contributed_second]){
 					continue;
 				} else{
 					num_contributed_second += 1;


### PR DESCRIPTION
Hi,
I was attempting to build and install the project and encountered build errors in `diff-gaussian-rasterization`. I found it to be caused by `u_int16_t` and `u_int32_t` being unknown type names. As far as I can tell, this is a typo and it built correctly for me once corrected.

I am unsure whether there is more to this than meets the eye but this simple fix worked for me so I thought I would contribute it.

Cheers.